### PR TITLE
Bug 1782676: Do not hardcode GOARCH=amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ check-docker:
 docker-binary: BINDIR = ./rootfs
 docker-binary: GOFLAGS += -a -installsuffix cgo
 docker-binary:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/tiller $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR)/tiller $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
 
 .PHONY: docker-build
 docker-build: check-docker docker-binary
@@ -71,7 +71,7 @@ docker-build: check-docker docker-binary
 docker-binary-rudder: BINDIR = ./rootfs
 docker-binary-rudder: GOFLAGS += -a -installsuffix cgo
 docker-binary-rudder:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/rudder $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/rudder
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR)/rudder $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/rudder
 
 .PHONY: docker-build-experimental
 docker-build-experimental: check-docker docker-binary docker-binary-rudder


### PR DESCRIPTION
This is necessary for multi-arch support.