### PR TITLE
Updating ose-metering-helm builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS build
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS build
 
 RUN yum install --setopt=skip_missing_names_on_install=False -y \
         hg git make \
@@ -16,7 +16,7 @@ ENV VERSION ""
 RUN make build
 RUN make docker-binary
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 COPY --from=build /go/src/k8s.io/helm/rootfs/tiller /usr/local/bin
 COPY --from=build /go/src/k8s.io/helm/bin/helm /usr/local/bin


### PR DESCRIPTION
Updating ose-metering-helm builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-metering-helm.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
