### PR TITLE
pkg,internal: Remove any symbolic links that references a file outside of the repository

### DIFF
--- a/internal/third_party/dep/fs/fs_test.go
+++ b/internal/third_party/dep/fs/fs_test.go
@@ -414,9 +414,9 @@ func TestCopyFileSymlink(t *testing.T) {
 	defer cleanUpDir(tempdir)
 
 	testcases := map[string]string{
-		filepath.Join("./testdata/symlinks/file-symlink"):         filepath.Join(tempdir, "dst-file"),
-		filepath.Join("./testdata/symlinks/windows-file-symlink"): filepath.Join(tempdir, "windows-dst-file"),
-		filepath.Join("./testdata/symlinks/invalid-symlink"):      filepath.Join(tempdir, "invalid-symlink"),
+		filepath.Join("./testdata/symlinks/file-symlink"): filepath.Join(tempdir, "dst-file"),
+		// filepath.Join("./testdata/symlinks/windows-file-symlink"): filepath.Join(tempdir, "windows-dst-file"),
+		// filepath.Join("./testdata/symlinks/invalid-symlink"):      filepath.Join(tempdir, "invalid-symlink"),
 	}
 
 	for symlink, dst := range testcases {

--- a/internal/third_party/dep/fs/testdata/symlinks/invalid-symlink
+++ b/internal/third_party/dep/fs/testdata/symlinks/invalid-symlink
@@ -1,1 +1,0 @@
-/non/existing/file

--- a/internal/third_party/dep/fs/testdata/symlinks/windows-file-symlink
+++ b/internal/third_party/dep/fs/testdata/symlinks/windows-file-symlink
@@ -1,1 +1,0 @@
-C:/Users/ibrahim/go/src/github.com/golang/dep/internal/fs/testdata/test.file

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -47,19 +46,19 @@ func TestLoadDir(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
-func TestLoadDirWithDevNull(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test only works on unix systems with /dev/null present")
-	}
+// func TestLoadDirWithDevNull(t *testing.T) {
+// 	if runtime.GOOS == "windows" {
+// 		t.Skip("test only works on unix systems with /dev/null present")
+// 	}
 
-	l, err := Loader("testdata/frobnitz_with_dev_null")
-	if err != nil {
-		t.Fatalf("Failed to load testdata: %s", err)
-	}
-	if _, err := l.Load(); err == nil {
-		t.Errorf("packages with an irregular file (/dev/null) should not load")
-	}
-}
+// 	l, err := Loader("testdata/frobnitz_with_dev_null")
+// 	if err != nil {
+// 		t.Fatalf("Failed to load testdata: %s", err)
+// 	}
+// 	if _, err := l.Load(); err == nil {
+// 		t.Errorf("packages with an irregular file (/dev/null) should not load")
+// 	}
+// }
 
 func TestLoadDirWithSymlink(t *testing.T) {
 	sym := filepath.Join("..", "LICENSE")

--- a/pkg/chart/loader/testdata/frobnitz_with_dev_null/null
+++ b/pkg/chart/loader/testdata/frobnitz_with_dev_null/null
@@ -1,1 +1,0 @@
-/dev/null


### PR DESCRIPTION
Remove any symbolic link that resolves to a file outside of the repository path (e.g. `testdata/frobnitz_with_dev_null/null -> /dev/null`) to avoid Cachito failures in the downstream pipeline.

Disable (i.e. comment out) any unit test that attempts to load these now removed files in the [pkg,internal] packages.

Due to recent changes made to Cachito, any symbolic link that points to a file outside of the cloned repository will fail a bundle request.

Symbolic links were found using the following command:

```bash
$ find . -type l -ls`
```

Note: this is a squashed commit of the commits detailed in the `timflannagan1/helm@tflannag-cachito-adventures` branch.
